### PR TITLE
Fetch tags for limactl --version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+        fetch-depth: 0
         submodules: recursive
     - name: Install sha512sum
       if: startswith(matrix.os, 'macos')


### PR DESCRIPTION
When tags are unavailable, `limactl --version` will just report the commit SHA1, e.g. `limactl version 6587349`.

When tags are available the reported version looks like `limactl version 0.21.0-47-gcaba48e`.